### PR TITLE
Refactor Client struct to include instance-specific headers  

### DIFF
--- a/client.go
+++ b/client.go
@@ -8,8 +8,9 @@ import (
 )
 
 type Client struct {
-	ctx    context.Context
-	apiKey string
+	ctx     context.Context
+	apiKey  string
+	headers []goxios.Header
 }
 
 type OpenAIClient interface {
@@ -17,6 +18,7 @@ type OpenAIClient interface {
 	ApiKey() string
 	BaseURL() string
 	AddHeader(goxios.Header)
+	Headers() []goxios.Header
 }
 
 type HTTPClient interface {
@@ -37,7 +39,7 @@ func (c *Client) ApiKey() string {
 }
 
 func New(ctx context.Context, apiKey string) *Client {
-	openaiClient := &Client{ctx, apiKey}
+	openaiClient := &Client{ctx, apiKey, []goxios.Header{}}
 	openaiClient.setAuthorizationHeader()
 	return openaiClient
 }

--- a/completion.go
+++ b/completion.go
@@ -108,7 +108,7 @@ func ChatCompletion[Messages any](api OpenAIClient, httpClient HTTPClient, body 
 		return nil, errCannotMarshalJSON(err)
 	}
 	options := &goxios.RequestOpts{
-		Headers: Headers(),
+		Headers: api.Headers(),
 		Body:    ioReader(b),
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/chat/completions", options)

--- a/completion_test.go
+++ b/completion_test.go
@@ -25,6 +25,8 @@ func (c MockClient) BaseURL() string {
 
 func (c MockClient) AddHeader(h goxios.Header) {}
 
+func (c MockClient) Headers() []goxios.Header { return []goxios.Header{} }
+
 type testHTTPClient struct {
 	req *http.Request
 }

--- a/embedding.go
+++ b/embedding.go
@@ -52,7 +52,7 @@ func CreateEmbedding[Input string | []string, Encoding []float64 | Base64](api O
 		return nil, errCannotMarshalJSON(err)
 	}
 	options := goxios.RequestOpts{
-		Headers: Headers(),
+		Headers: api.Headers(),
 		Body:    ioReader(b),
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/embeddings", &options)

--- a/headers.go
+++ b/headers.go
@@ -5,18 +5,17 @@ import (
 )
 
 var (
-	headers         = []goxios.Header{}
 	contentTypeJSON = goxios.Header{Key: "Content-Type", Value: "application/json"}
 )
 
 func (c *Client) setAuthorizationHeader() {
-	headers = append(headers, goxios.Header{Key: "Authorization", Value: "Bearer " + c.apiKey})
+	c.headers = append(c.headers, goxios.Header{Key: "Authorization", Value: "Bearer " + c.apiKey})
 }
 
 func (c *Client) AddHeader(h goxios.Header) {
-	headers = append(headers, h)
+	c.headers = append(c.headers, h)
 }
 
-func Headers() []goxios.Header {
-	return headers
+func (c *Client) Headers() []goxios.Header {
+	return c.headers
 }

--- a/image.go
+++ b/image.go
@@ -76,7 +76,7 @@ func ImagesGenerations(api OpenAIClient, httpClient HTTPClient, body *ImagesGene
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/images/generations", &goxios.RequestOpts{
 		Body:    ioReader(b),
-		Headers: Headers(),
+		Headers: api.Headers(),
 	})
 	if err != nil {
 		return nil, errCannotSendRequest(err)

--- a/moderation.go
+++ b/moderation.go
@@ -31,7 +31,7 @@ func Moderator[Input string | []string](api OpenAIClient, httpClient HTTPClient,
 	}
 	options := goxios.RequestOpts{
 		Body:    ioReader(b),
-		Headers: Headers(),
+		Headers: api.Headers(),
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/moderations", &options)
 	if err != nil {

--- a/tts.go
+++ b/tts.go
@@ -52,7 +52,7 @@ func TextToSpeech(api OpenAIClient, httpClient HTTPClient, body *SpeechRequestBo
 		return nil, NewOpenAIErr(err, 500, "marshal_json_error")
 	}
 	options := goxios.RequestOpts{
-		Headers: Headers(),
+		Headers: api.Headers(),
 		Body:    ioReader(b),
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/audio/speech", &options)

--- a/whisper.go
+++ b/whisper.go
@@ -46,7 +46,7 @@ func Transcription(api OpenAIClient, httpClient HTTPClient, body *Transcriptions
 
 	api.AddHeader(goxios.Header{Key: "Content-Type", Value: writer.FormDataContentType()})
 	requestOptions := goxios.RequestOpts{
-		Headers: Headers(),
+		Headers: api.Headers(),
 		Body:    b,
 	}
 	res, err := httpClient.Post(api.BaseURL()+"/audio/transcriptions", &requestOptions)


### PR DESCRIPTION
- Updated `Client` struct to store `headers` as an instance-specific field instead of using a package-level variable.
- Modified `OpenAIClient` interface to include `Headers` method. 
- Updated `setAuthorizationHeader` method to add headers to the instance-specific field.
- Updated `AddHeader` method to add headers to the instance-specific field. 
- Added `Headers` method to return instance-specific headers.